### PR TITLE
Fixing build failures after kernel update: Makefile "KPATH" -> "KERNELDIR" to match the entry in dkms.conf. Also making the assignment conditional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 .github
+*.cmd
+*.order
+*.ko
+*.mod
+*.mod.c
+*.mod.o
+*.o
+Module.symvers

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 MOD = intel_msr
 MOD_VER = 1.0
-KPATH := /lib/modules/$(shell uname -r)/build
+KERNELDIR?=/lib/modules/$(shell uname -r)/build
 MOD_SOURCE_PATH := /usr/src/intel_msr-1.0/
 DKMS_MOD_PATH := /var/lib/dkms/intel_msr
 PWD := $(shell pwd)
 obj-m = $(MOD).o
 
 all:
-	$(MAKE) -C $(KPATH) M=$(PWD) modules
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 clean:
-	$(MAKE) -C $(KPATH) M=$(PWD) clean
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
 
 insmod: all
 	sudo rmmod $(MOD).ko; true


### PR DESCRIPTION
When upgrading the kernel on my system, I noticed that the automatic build fails

```
( 8/23) Install DKMS modules
==> dkms install --no-depmod -m intel_msr -v 1.0 -k 5.10.61-1-MANJARO
Error! Bad return status for module build on kernel: 5.10.61-1-MANJARO (x86_64)
Consult /var/lib/dkms/intel_msr/1.0/build/make.log for more information.
==> Warning, `dkms install --no-depmod -m intel_msr -v 1.0 -k 5.10.61-1-MANJARO' returned 10
==> dkms install --no-depmod -m leetmouse-driver -v 0.9.0 -k 5.10.61-1-MANJARO
==> dkms install --no-depmod -m openafs -v 1.8.8 -k 5.10.61-1-MANJARO
==> depmod 5.10.61-1-MANJARO
```

One can clearly see, that dkms wants to build the modules for 5.10.61-1-MANJARO. The live kernel however is 5.10-60.
The "kernelver" variable when parsing the dkms.conf of this module is set to the  5.10.61 kernel version. 
In dkms.conf, this is respected for the KERNELDIR variable, which is supposed to get passed over to the Makefile.. 
However KERNELDIR is nowhere used in the Makefile, but KPATH takes its place.
Renaming KPATH -> KERNELDIR in the Makefile or KERNELDIR -> KPATH in the dkms.conf is one part of the solution. One also needs to make the assignment in the Makefile conditional (?= instead of :=), so that dkms can set it externally.

The PR fixes this by editing the Makefile